### PR TITLE
update xarray opening of zarr

### DIFF
--- a/notebooks/cmip6-zarr-jasmin.ipynb
+++ b/notebooks/cmip6-zarr-jasmin.ipynb
@@ -208,7 +208,7 @@
     "def cat_to_ds(cat):\n",
     "    zarr_path = cat.df['zarr_path'][0]\n",
     "    fsmap = fsspec.get_mapper(zarr_path)\n",
-    "    return xr.open_zarr(fsmap, consolidated=True, use_cftime=True)"
+    "    return xr.open_dataset(fsmap, consolidated=True, use_cftime=True, engine='zarr')"
    ]
   },
   {


### PR DESCRIPTION
This updates the deprecated call to `xarray.open_zarr()` which results in an error as described in issue cedadev/cmip6-object-store#51.